### PR TITLE
Enable importing the library via find_package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - docker run -it -d --env LD_LIBRARY_PATH=/usr/local/lib --volume $(pwd):/root/netutils:ro --workdir=/root --name $CONTAINER_NAME djarek/boost-docker:gcc-7-boost-1.67.0 bash
 
 script:
-  - docker exec $CONTAINER_NAME ctest --output-on-failure -V -S netutils/CMakeModules/ci_build.cmake
+  - docker exec $CONTAINER_NAME ctest --output-on-failure -VV -S netutils/CMakeModules/ci_build.cmake
 
 after_success:
   - docker cp $CONTAINER_NAME:/root/build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,44 @@
-cmake_minimum_required(VERSION 3.6)
-project(netutils LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.8)
+project(netutils VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
-find_package(Boost 1.66 COMPONENTS system unit_test_framework REQUIRED)
+
+find_package(Boost 1.67 COMPONENTS system unit_test_framework REQUIRED)
+find_package (Threads)
 
 
-add_library(netutils INTERFACE)
-target_include_directories(netutils INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+add_library(core INTERFACE)
+
+target_compile_features(core INTERFACE cxx_std_11)
+
+target_include_directories(core INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(netutils INTERFACE ${Boost_LIBRARIES} -pthread netutils)
 
+target_link_libraries(core INTERFACE ${Boost_LIBRARIES} Threads::Threads)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("netutilsConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(FILES "netutilsConfig.cmake" "${CMAKE_BINARY_DIR}/netutilsConfigVersion.cmake" DESTINATION lib/cmake/netutils)
+
+install (
+    DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.hpp")
+
+install(TARGETS core EXPORT netutilsTargets INCLUDES DESTINATION include)
+install(EXPORT netutilsTargets
+        FILE netutilsTargets.cmake
+        NAMESPACE netu::
+        DESTINATION lib/cmake/netutils
+)
 
 enable_testing()
 include(CTest)
 add_subdirectory(tests)
-
-install (
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-    DESTINATION include
-    FILES_MATCHING PATTERN "*.hpp")
-
-install(TARGETS netutils EXPORT netutilsTargets INCLUDES DESTINATION include)
-install(EXPORT netutilsTargets
-        FILE netutilsTargets.cmake
-        NAMESPACE netu::
-        DESTINATION lib/cmake/netu
-)

--- a/netutilsConfig.cmake
+++ b/netutilsConfig.cmake
@@ -1,0 +1,4 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(Boost COMPONENTS system)
+include("${CMAKE_CURRENT_LIST_DIR}/netutilsTargets.cmake")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,14 +5,13 @@ set (netu_tests_srcs
 function (netutils_add_test test_file)
     get_filename_component(target_name ${test_file} NAME_WE)
     add_executable(${target_name} ${test_file})
-    target_link_libraries(${target_name} netutils ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-    target_compile_options(${target_name} PUBLIC -std=c++11 -Wall -Wextra -pedantic)
+    target_link_libraries(${target_name} core ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+    target_compile_options(${target_name} PUBLIC -Wall -Wextra -pedantic)
     target_compile_definitions(${target_name} PRIVATE BOOST_TEST_DYN_LINK BOOST_TEST_MODULE="${target_name}")
 
     target_include_directories(${target_name} PRIVATE extras/include)
 
-    add_test("${PROJECT_NAME}_${target_name}_tests" ${target_name})
-    #target_compile_features(completion_handler_test PRIVATE cxx_std_11)
+    add_test(NAME "${target_name}_tests" COMMAND ${target_name})
 endfunction(netutils_add_test)
 
 foreach(test_src_name IN ITEMS ${netu_tests_srcs})


### PR DESCRIPTION
The library will now be importable from 3rd party projects via find_package(), after the project has been installed (e.g. with make install).

* the core library target has been renamed from netutils to core
* CMake version 3.8 or higher is required
* the core library will now expose the c++11 or higher requirement
  in its INTERFACE
