### PR TITLE
synchronized_value vocabulary type

### DIFF
--- a/include/netu/impl/synchronized_value.hpp
+++ b/include/netu/impl/synchronized_value.hpp
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2018 Damian Jarek (damian dot jarek93 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/djarek/netutils
+//
+
+#ifndef NETU_IMPL_SYNCHRONIZED_VALUE_HPP
+#define NETU_IMPL_SYNCHRONIZED_VALUE_HPP
+
+#include <netu/synchronized_value.hpp>
+
+namespace netu
+{
+
+namespace detail
+{
+
+template<typename Lockable>
+class adopting_lock_guard
+{
+public:
+    explicit adopting_lock_guard(Lockable& l) noexcept
+      : guard_{l, std::adopt_lock}
+    {
+    }
+
+private:
+    std::lock_guard<Lockable> guard_;
+};
+
+template<typename Lockable>
+auto
+lock(Lockable& l) -> Lockable&
+{
+    l.lock();
+    return l;
+}
+
+template<typename Lockable1, typename Lockable2, typename... Lockables>
+auto
+lock(Lockable1& l1, Lockable2& l2, Lockables&... ls)
+  -> decltype(std::tie(l1, l2, ls...))
+{
+    std::lock(l1, l2, ls...);
+    return std::tie(l1, l2, ls...);
+}
+
+template<typename... Lockables>
+class scoped_lock
+{
+public:
+    explicit scoped_lock(Lockables&... ls)
+      : guards_{detail::lock(ls...)}
+    {
+    }
+
+private:
+    std::tuple<detail::adopting_lock_guard<Lockables>...> guards_;
+};
+
+} // namespace detail
+
+template<typename Callable, typename... Ts, typename... Lockables>
+auto
+apply(Callable&& f, synchronized_value<Ts, Lockables>&... svs)
+  -> decltype(std::forward<Callable>(f)(svs.value_...))
+{
+    detail::scoped_lock<Lockables...> guard{svs.mutex_...};
+    return std::forward<Callable>(f)(svs.value_...);
+}
+
+template<typename Callable, typename... Ts, typename... Lockables>
+auto
+apply(Callable&& f, synchronized_value<Ts, Lockables> const&... svs)
+  -> decltype(std::forward<Callable>(f)(svs.value_...))
+{
+    detail::scoped_lock<Lockables...> guard{svs.mutex_...};
+    return std::forward<Callable>(f)(svs.value_...);
+}
+
+} // namespace netu
+
+#endif // NETU_SYNCHRONIZED_VALUE_HPP

--- a/include/netu/synchronized_value.hpp
+++ b/include/netu/synchronized_value.hpp
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2018 Damian Jarek (damian dot jarek93 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/djarek/netutils
+//
+
+#ifndef NETU_SYNCHRONIZED_VALUE_HPP
+#define NETU_SYNCHRONIZED_VALUE_HPP
+
+#include <mutex>
+#include <utility>
+
+namespace netu
+{
+
+template<typename T, typename Lockable = std::mutex>
+class synchronized_value
+{
+public:
+    using value_type = T;
+    using mutex_type = Lockable;
+
+    synchronized_value() = default;
+
+    template<typename Arg1, typename... Args>
+    explicit synchronized_value(Arg1&& arg1, Args&&... args)
+      : value_{std::forward<Arg1>(arg1), std::forward<Args>(args)...}
+    {
+    }
+
+    synchronized_value(synchronized_value&&) = delete;
+    synchronized_value(synchronized_value const&) = delete;
+
+    synchronized_value& operator=(synchronized_value&&) = delete;
+    synchronized_value& operator=(synchronized_value const&) = delete;
+
+    ~synchronized_value() = default;
+
+    template<typename Callable, typename... Ts, typename... Lockables>
+    friend auto apply(Callable&& f, synchronized_value<Ts, Lockables>&... svs)
+      -> decltype(std::forward<Callable>(f)(svs.value_...));
+
+    template<typename Callable, typename... Ts, typename... Lockables>
+    friend auto apply(Callable&& f,
+                      synchronized_value<Ts, Lockables> const&... svs)
+      -> decltype(std::forward<Callable>(f)(svs.value_...));
+
+private:
+    T value_;
+    mutable Lockable mutex_;
+};
+
+} // namespace netu
+
+#include <netu/impl/synchronized_value.hpp>
+
+#endif // NETU_SYNCHRONIZED_VALUE_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (netu_tests_srcs
-    netu/completion_handler.cpp)
+    netu/completion_handler.cpp
+    netu/synchronized_value.cpp)
 
 function (netutils_add_test test_file)
     get_filename_component(target_name ${test_file} NAME_WE)

--- a/tests/netu/synchronized_value.cpp
+++ b/tests/netu/synchronized_value.cpp
@@ -1,0 +1,126 @@
+//
+// Copyright (c) 2018 Damian Jarek (damian dot jarek93 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/djarek/netutils
+//
+
+#include <netu/synchronized_value.hpp>
+
+#include <boost/noncopyable.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <unordered_set>
+
+namespace netu
+{
+
+namespace
+{
+
+std::unordered_set<void*> lock_set;
+
+struct fake_basic_lockable : boost::noncopyable
+{
+    void lock()
+    {
+        auto pair = lock_set.insert(this);
+        BOOST_ASSERT(pair.second);
+    }
+
+    void unlock() noexcept
+    {
+        auto erased = lock_set.erase(this);
+        BOOST_ASSERT(erased == 1);
+    }
+
+    ~fake_basic_lockable()
+    {
+        auto count = lock_set.count(this);
+        BOOST_ASSERT(count == 0);
+    }
+};
+
+struct fake_lockable : boost::noncopyable
+{
+    void lock()
+    {
+        auto pair = lock_set.insert(this);
+        BOOST_ASSERT(pair.second);
+    }
+
+    bool try_lock()
+    {
+        lock();
+        return true;
+    }
+
+    void unlock() noexcept
+    {
+        auto erased = lock_set.erase(this);
+        BOOST_ASSERT(erased == 1);
+    }
+
+    ~fake_lockable()
+    {
+        auto count = lock_set.count(this);
+        BOOST_ASSERT(count == 0);
+    }
+};
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(single_value_apply)
+{
+    synchronized_value<int, fake_basic_lockable> sv1{42};
+    synchronized_value<int, fake_basic_lockable> sv2{43};
+
+    auto v = apply(
+      [](int& v) {
+          BOOST_TEST(lock_set.size() == 1);
+          return v;
+      },
+      sv1);
+    BOOST_TEST(v == 42);
+    BOOST_TEST(lock_set.empty());
+
+    v = apply(
+      [](int const& v) {
+          BOOST_TEST(lock_set.size() == 1);
+          return v;
+      },
+      static_cast<decltype(sv2) const &>(sv2));
+    BOOST_TEST(v == 43);
+    BOOST_TEST(lock_set.empty());
+}
+
+BOOST_AUTO_TEST_CASE(multi_value_apply)
+{
+    synchronized_value<int, fake_lockable> sv1{42};
+    synchronized_value<int, fake_lockable> sv2{43};
+
+    auto v = apply(
+      [](int& v1, int& v2) {
+          BOOST_TEST(lock_set.size() == 2);
+          auto v = v1;
+          v1 = v2;
+          return v;
+      },
+      sv1,
+      sv2);
+    BOOST_TEST(v == 42);
+
+    v = apply(
+      [](int const& v1, int const& v2) {
+          BOOST_TEST(lock_set.size() == 2);
+          return v1 + v2;
+      },
+      static_cast<decltype(sv1) const &>(sv1),
+      static_cast<decltype(sv2) const &>(sv2));
+
+    BOOST_TEST(v == 43 * 2);
+}
+
+} // namespace netu


### PR DESCRIPTION
The synchronized_value type is useful for binding a value with a mutex and reducing the chance of forgetting to lock a mutex. While it does not fully prevent deadlocks, it does have an apply() method which allows gaining synchronized access to multiple synchronized_values at the same time, by using a deadlock avoidance algorithm based on try_lock().
