### PR TITLE
Fix async utils header guard && replace decay

### DIFF
--- a/include/netu/detail/async_utils.hpp
+++ b/include/netu/detail/async_utils.hpp
@@ -7,8 +7,8 @@
 // Official repository: https://github.com/djarek/netutils
 //
 
-#ifndef NETU_DETAIL_TYPE_TRAITS_HPP
-#define NETU_DETAIL_TYPE_TRAITS_HPP
+#ifndef NETU_DETAIL_ASYNC_UTILS_HPP
+#define NETU_DETAIL_ASYNC_UTILS_HPP
 
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/is_executor.hpp>
@@ -72,4 +72,4 @@ using executor_from_context_t =
 } // namespace detail
 } // namespace netu
 
-#endif // NETU_DETAIL_TYPE_TRAITS_HPP
+#endif // NETU_DETAIL_ASYNC_UTILS_HPP

--- a/include/netu/detail/type_traits.hpp
+++ b/include/netu/detail/type_traits.hpp
@@ -26,10 +26,13 @@ exchange(T& obj, U&& val)
     obj = std::forward<U>(val);
     return old;
 }
+template<typename T>
+using remove_cv_ref_t =
+  typename std::remove_cv<typename std::remove_reference<T>::type>::type;
 
 template<typename From, typename To>
 using disable_conversion_t = typename std::enable_if<
-  !std::is_same<To, typename std::decay<From>::type>::value>::type;
+  !std::is_same<To, remove_cv_ref_t<From>>::value>::type;
 
 } // namespace detail
 } // namespace netu


### PR DESCRIPTION
* The guard reused the same macro definition name, thus causing issues if both were included in the same file at the same time.
* Decay does too much type conversions, removing references and cv-qualifiers is enough.