### PR TITLE
basic_timeout_timer

### DIFF
--- a/include/netu/basic_timeout.hpp
+++ b/include/netu/basic_timeout.hpp
@@ -1,0 +1,93 @@
+//
+// Copyright (c) 2018 Damian Jarek (damian dot jarek93 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/djarek/netutils
+//
+
+#ifndef NETU_BASIC_TIMEOUT_HPP
+#define NETU_BASIC_TIMEOUT_HPP
+
+#include <netu/completion_handler.hpp>
+#include <netu/detail/async_utils.hpp>
+
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/beast/core/bind_handler.hpp>
+#include <boost/intrusive/set.hpp>
+
+namespace netu
+{
+
+namespace detail
+{
+template<typename Timer>
+class basic_timeout_service;
+} // namespace detail
+
+template<typename Timer>
+class basic_timeout
+  : public boost::asio::basic_io_object<detail::basic_timeout_service<Timer>>
+{
+public:
+    using timer_type = Timer;
+    using clock_type = typename Timer::clock_type;
+    using duration = typename clock_type::duration;
+    using executor_type = typename timer_type::executor_type;
+    using time_point = typename clock_type::time_point;
+    using traits_type = typename Timer::traits_type;
+
+    explicit basic_timeout(boost::asio::io_context& ctx)
+      : boost::asio::basic_io_object<detail::basic_timeout_service<Timer>>{ctx}
+    {
+    }
+
+    // basic_timeout(boost::asio::io_context& ctx, duration d)
+    //   : timer_{ctx, std::move(d)}
+    // {
+    // }
+
+    // basic_timeout(boost::asio::io_context& ctx, time_point tp)
+    //   : timer_{ctx, std::move(tp)}
+    // {
+    // }
+
+    template<typename CompletionToken>
+    auto async_wait(CompletionToken&& tok)
+      -> detail::wait_completion_result_t<CompletionToken>
+
+    {
+        return this->get_service().async_wait(
+          this->get_implementation(), std::forward<CompletionToken>(tok));
+    }
+
+    bool expires_from_now(duration d)
+    {
+        return this->get_service().expires_from_now(this->get_implementation(),
+                                                    d);
+    }
+
+    bool cancel()
+    {
+        return this->get_service().cancel(this->get_implementation());
+    }
+
+    time_point expiry() const
+    {
+        return this->get_service().expiry(this->get_implementation());
+    }
+
+    Timer& get_timer()
+    {
+        return this->get_service().timer_;
+    }
+};
+
+} // namespace netu
+
+#include <netu/impl/basic_timeout.hpp>
+
+#endif // NETU_BASIC_TIMEOUT_HPP

--- a/include/netu/basic_timeout.hpp
+++ b/include/netu/basic_timeout.hpp
@@ -79,11 +79,6 @@ public:
     {
         return this->get_service().expiry(this->get_implementation());
     }
-
-    Timer& get_timer()
-    {
-        return this->get_service().timer_;
-    }
 };
 
 } // namespace netu

--- a/include/netu/detail/async_utils.hpp
+++ b/include/netu/detail/async_utils.hpp
@@ -49,26 +49,6 @@ template<typename CompletionToken>
 using wait_completion_handler_t =
   typename wait_completion_t<CompletionToken>::completion_handler_type;
 
-template<template<typename...> class AsyncOp,
-         typename... Us,
-         typename CompletionToken,
-         typename... Ts,
-         typename... Args>
-auto
-make_composed_op(
-  boost::asio::async_completion<CompletionToken, void(Ts...)>& init,
-  Args&&... args)
-  -> AsyncOp<typename boost::asio::async_completion<
-               CompletionToken,
-               void(Ts...)>::completion_handler_type,
-             Us...>
-{
-    using ch_t = typename boost::asio::
-      async_completion<CompletionToken, void(Ts...)>::completion_handler_type;
-    return AsyncOp<ch_t, Us...>{std::move(init.completion_handler),
-                                std::forward<Args>(args)...};
-}
-
 template<typename T, typename = void>
 struct has_executor : std::false_type
 {

--- a/include/netu/impl/basic_timeout.hpp
+++ b/include/netu/impl/basic_timeout.hpp
@@ -184,10 +184,7 @@ public:
     // private:
     void reschedule()
     {
-        if (timeouts_.empty())
-        {
-            return;
-        }
+        BOOST_ASSERT(!timeouts_.empty());
 
         timer_.expires_at(timeouts_.begin()->expiry);
         timer_.async_wait([this](boost::system::error_code ec) {

--- a/include/netu/impl/basic_timeout.hpp
+++ b/include/netu/impl/basic_timeout.hpp
@@ -1,0 +1,234 @@
+//
+// Copyright (c) 2018 Damian Jarek (damian dot jarek93 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/djarek/netutils
+//
+
+#ifndef NETU_IMPL_BASIC_TIMEOUT_HPP
+#define NETU_IMPL_BASIC_TIMEOUT_HPP
+#include <netu/basic_timeout.hpp>
+
+namespace netu
+{
+namespace detail
+{
+
+struct timeout_entry : boost::intrusive::set_base_hook<>
+{
+    std::chrono::steady_clock::time_point expiry;
+    completion_handler<void(boost::system::error_code)> handler;
+
+    friend bool operator<(timeout_entry const& lhs,
+                          timeout_entry const& rhs) noexcept
+    {
+        return lhs < rhs;
+    }
+};
+
+bool
+try_invoke(completion_handler<void(boost::system::error_code)>& handler,
+           boost::system::error_code ec)
+{
+    if (handler)
+    {
+        handler.invoke(ec);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+template<typename TimePoint>
+bool
+expired(timeout_entry const& e, TimePoint now)
+{
+    return e.expiry < now;
+}
+
+template<typename T>
+bool
+is_first_in(T const& t, boost::intrusive::set<T> const& l)
+{
+    auto const it = boost::intrusive::set<T>::s_iterator_to(t);
+    return it == l.begin();
+}
+
+template<typename CompletionHandler, typename Executor>
+class suspended_handler
+{
+public:
+    using allocator_type =
+      boost::asio::associated_allocator_t<CompletionHandler>;
+
+    explicit suspended_handler(CompletionHandler&& handler, Executor e)
+      : handler_{std::forward<CompletionHandler>(handler)}
+      , guard_{std::move(e)}
+    {
+    }
+
+    allocator_type get_allocator() const noexcept
+    {
+        return boost::asio::get_associated_allocator(handler_);
+    }
+
+    template<typename... Args>
+    void operator()(Args&&... args)
+    {
+        boost::asio::post(
+          guard_.get_executor(),
+          boost::beast::bind_handler(std::move(handler_), args...));
+    }
+
+private:
+    CompletionHandler handler_;
+    boost::asio::executor_work_guard<Executor> guard_;
+};
+
+template<typename Timer>
+class basic_timeout_service : public boost::asio::io_context::service
+{
+public:
+    static const boost::asio::io_context::id id;
+
+    using implementation_type = timeout_entry;
+    using list_type = boost::intrusive::set<timeout_entry>;
+    using timer_type = Timer;
+    using clock_type = typename Timer::clock_type;
+    using duration = typename clock_type::duration;
+    using time_point = typename clock_type::time_point;
+
+    explicit basic_timeout_service(boost::asio::io_context& ctx)
+      : boost::asio::io_context::service{ctx}
+      , timer_{ctx}
+    {
+    }
+
+    void construct(timeout_entry&)
+    {
+    }
+
+    void destroy(timeout_entry& e)
+    {
+        if (e.is_linked())
+        {
+            timeouts_.erase(list_type::s_iterator_to(e));
+        }
+        try_invoke(e.handler, boost::asio::error::operation_aborted);
+    }
+
+    template<typename CompletionToken>
+    auto async_wait(timeout_entry& e, CompletionToken&& tok)
+      -> detail::wait_completion_result_t<CompletionToken>
+    {
+        detail::wait_completion_t<CompletionToken> init{tok};
+
+        using ch_t = typename decltype(init)::completion_handler_type;
+        auto handler =
+          suspended_handler<ch_t, boost::asio::io_context::executor_type>{
+            std::move(init.completion_handler),
+            this->get_io_context().get_executor()};
+
+        if (expired(e, clock_type::now()))
+        {
+            auto const ec = boost::system::error_code{};
+            handler(ec);
+        }
+        else
+        {
+            e.handler = std::move(handler);
+        }
+
+        return init.result.get();
+    }
+
+    bool expires_from_now(timeout_entry& e, duration d)
+    {
+        bool needs_reschedule = timeouts_.empty();
+        bool const was_linked = e.is_linked();
+        if (was_linked)
+        {
+            needs_reschedule = is_first_in(e, timeouts_);
+            timeouts_.erase(list_type::s_iterator_to(e));
+        }
+        e.expiry = clock_type::now() + d;
+        timeouts_.insert(e);
+
+        if (needs_reschedule)
+        {
+            reschedule();
+        }
+
+        return was_linked;
+    }
+
+    bool cancel(timeout_entry& e)
+    {
+        if (e.is_linked())
+        {
+            bool const needs_reschedule = is_first_in(e, timeouts_);
+            timeouts_.erase(list_type::s_iterator_to(e));
+            if (needs_reschedule && !timeouts_.empty())
+            {
+                reschedule();
+            }
+        }
+
+        return try_invoke(e.handler, boost::asio::error::operation_aborted);
+    }
+
+    // private:
+    void reschedule()
+    {
+        if (timeouts_.empty())
+        {
+            return;
+        }
+
+        timer_.expires_at(timeouts_.begin()->expiry);
+        timer_.async_wait([this](boost::system::error_code ec) {
+            if (ec)
+            {
+                return;
+            }
+
+            auto const now = clock_type::now();
+            static auto const rescheduler = [](basic_timeout_service* service) {
+                if (!service->timeouts_.empty())
+                {
+                    service->reschedule();
+                }
+            };
+            std::unique_ptr<basic_timeout_service, decltype(rescheduler)> guard{
+              this, rescheduler};
+
+            for (auto it = timeouts_.begin(); it != timeouts_.end();)
+            {
+                if (!expired(*it, now))
+                {
+                    break;
+                }
+
+                auto& entry = *it;
+                it = timeouts_.erase(it);
+                try_invoke(entry.handler, ec);
+            }
+        });
+    }
+
+    Timer timer_;
+    list_type timeouts_;
+};
+
+template<typename Timer>
+boost::asio::io_context::id const basic_timeout_service<Timer>::id;
+
+} // namespace detail
+
+} // namespace netu
+
+#endif // NETU_IMPL_BASIC_TIMEOUT_TIMER_HPP

--- a/include/netu/impl/basic_timeout.hpp
+++ b/include/netu/impl/basic_timeout.hpp
@@ -9,7 +9,9 @@
 
 #ifndef NETU_IMPL_BASIC_TIMEOUT_HPP
 #define NETU_IMPL_BASIC_TIMEOUT_HPP
+
 #include <netu/basic_timeout.hpp>
+#include <netu/synchronized_value.hpp>
 
 namespace netu
 {
@@ -28,7 +30,7 @@ struct timeout_entry : boost::intrusive::set_base_hook<>
     }
 };
 
-bool
+inline bool
 try_invoke(completion_handler<void(boost::system::error_code)>& handler,
            boost::system::error_code ec)
 {
@@ -102,9 +104,20 @@ public:
     using duration = typename clock_type::duration;
     using time_point = typename clock_type::time_point;
 
+    struct state
+    {
+        explicit state(boost::asio::io_context& ctx)
+          : timer_{ctx}
+        {
+        }
+
+        Timer timer_;
+        list_type timeouts_;
+    };
+
     explicit basic_timeout_service(boost::asio::io_context& ctx)
       : boost::asio::io_context::service{ctx}
-      , timer_{ctx}
+      , synchronized_state_{ctx}
     {
     }
 
@@ -112,113 +125,155 @@ public:
     {
     }
 
+    void move_construct(timeout_entry& to, timeout_entry& from)
+    {
+        apply([&to, &from](state&) { to = detail::exchange(from, {}); },
+              synchronized_state_);
+    }
+
+    void move_assign(timeout_entry& to,
+                     basic_timeout_service& other,
+                     timeout_entry& from)
+    {
+        if (&other == this)
+        {
+            apply([&to, &from](state&) { to = detail::exchange(from, {}); },
+                  synchronized_state_);
+        }
+        else
+        {
+            apply(
+              [&to, &from](state&, state&) { to = detail::exchange(from, {}); },
+              synchronized_state_,
+              other.synchronized_state_);
+        }
+    }
+
     void destroy(timeout_entry& e)
     {
-        if (e.is_linked())
-        {
-            timeouts_.erase(list_type::s_iterator_to(e));
-        }
-        try_invoke(e.handler, boost::asio::error::operation_aborted);
+        apply(
+          [&e](state& s) {
+              if (e.is_linked())
+              {
+                  s.timeouts_.erase(list_type::s_iterator_to(e));
+              }
+              try_invoke(e.handler, boost::asio::error::operation_aborted);
+          },
+          synchronized_state_);
     }
 
     template<typename CompletionToken>
     auto async_wait(timeout_entry& e, CompletionToken&& tok)
       -> detail::wait_completion_result_t<CompletionToken>
     {
-        detail::wait_completion_t<CompletionToken> init{tok};
 
-        using ch_t = typename decltype(init)::completion_handler_type;
-        auto handler =
-          suspended_handler<ch_t, boost::asio::io_context::executor_type>{
-            std::move(init.completion_handler),
-            this->get_io_context().get_executor()};
+        return apply(
+          [&e, &tok, this](state&) {
+              detail::wait_completion_t<CompletionToken> init{tok};
+              using ch_t = typename decltype(init)::completion_handler_type;
+              auto handler =
+                suspended_handler<ch_t, boost::asio::io_context::executor_type>{
+                  std::move(init.completion_handler),
+                  this->get_io_context().get_executor()};
 
-        if (expired(e, clock_type::now()))
-        {
-            auto const ec = boost::system::error_code{};
-            handler(ec);
-        }
-        else
-        {
-            e.handler = std::move(handler);
-        }
+              if (expired(e, clock_type::now()))
+              {
+                  auto const ec = boost::system::error_code{};
+                  handler(ec);
+              }
+              else
+              {
+                  e.handler = std::move(handler);
+              }
 
-        return init.result.get();
+              return init.result.get();
+          },
+          synchronized_state_);
     }
 
     bool expires_from_now(timeout_entry& e, duration d)
     {
-        bool needs_reschedule = timeouts_.empty();
-        bool const was_linked = e.is_linked();
-        if (was_linked)
-        {
-            needs_reschedule = is_first_in(e, timeouts_);
-            timeouts_.erase(list_type::s_iterator_to(e));
-        }
-        e.expiry = clock_type::now() + d;
-        timeouts_.insert(e);
+        return apply(
+          [&e, d, this](state& s) {
+              bool needs_reschedule = s.timeouts_.empty();
+              bool const was_linked = e.is_linked();
+              if (was_linked)
+              {
+                  needs_reschedule = is_first_in(e, s.timeouts_);
+                  s.timeouts_.erase(list_type::s_iterator_to(e));
+              }
+              e.expiry = clock_type::now() + d;
+              s.timeouts_.insert(e);
 
-        if (needs_reschedule)
-        {
-            reschedule();
-        }
+              if (needs_reschedule)
+              {
+                  reschedule(s);
+              }
 
-        return was_linked;
+              return was_linked;
+          },
+          synchronized_state_);
     }
 
     bool cancel(timeout_entry& e)
     {
-        if (e.is_linked())
-        {
-            bool const needs_reschedule = is_first_in(e, timeouts_);
-            timeouts_.erase(list_type::s_iterator_to(e));
-            if (needs_reschedule && !timeouts_.empty())
-            {
-                reschedule();
-            }
-        }
+        return apply(
+          [&e, this](state& s) {
+              if (e.is_linked())
+              {
+                  bool const needs_reschedule = is_first_in(e, s.timeouts_);
+                  s.timeouts_.erase(list_type::s_iterator_to(e));
+                  if (needs_reschedule && !s.timeouts_.empty())
+                  {
+                      reschedule(s);
+                  }
+              }
 
-        return try_invoke(e.handler, boost::asio::error::operation_aborted);
+              return try_invoke(e.handler,
+                                boost::asio::error::operation_aborted);
+          },
+          synchronized_state_);
     }
 
     // private:
-    void reschedule()
+    void reschedule(state& s)
     {
-        BOOST_ASSERT(!timeouts_.empty());
+        BOOST_ASSERT(!s.timeouts_.empty());
 
-        timer_.expires_at(timeouts_.begin()->expiry);
-        timer_.async_wait([this](boost::system::error_code ec) {
-            if (ec)
-            {
-                return;
-            }
+        s.timer_.expires_at(s.timeouts_.begin()->expiry);
+        s.timer_.async_wait(synchronize(
+          [this](state& s, boost::system::error_code ec) {
+              if (ec)
+              {
+                  return;
+              }
 
-            auto const now = clock_type::now();
-            static auto const rescheduler = [](basic_timeout_service* service) {
-                if (!service->timeouts_.empty())
-                {
-                    service->reschedule();
-                }
-            };
-            std::unique_ptr<basic_timeout_service, decltype(rescheduler)> guard{
-              this, rescheduler};
+              auto const now = clock_type::now();
+              static auto const rescheduler = [this](state* s) {
+                  if (!s->timeouts_.empty())
+                  {
+                      reschedule(*s);
+                  }
+              };
+              std::unique_ptr<state, decltype(rescheduler)> guard{&s,
+                                                                  rescheduler};
 
-            for (auto it = timeouts_.begin(); it != timeouts_.end();)
-            {
-                if (!expired(*it, now))
-                {
-                    break;
-                }
+              for (auto it = s.timeouts_.begin(); it != s.timeouts_.end();)
+              {
+                  if (!expired(*it, now))
+                  {
+                      break;
+                  }
 
-                auto& entry = *it;
-                it = timeouts_.erase(it);
-                try_invoke(entry.handler, ec);
-            }
-        });
+                  auto& entry = *it;
+                  it = s.timeouts_.erase(it);
+                  try_invoke(entry.handler, ec);
+              }
+          },
+          synchronized_state_));
     }
 
-    Timer timer_;
-    list_type timeouts_;
+    synchronized_value<state> synchronized_state_;
 };
 
 template<typename Timer>

--- a/include/netu/impl/basic_timeout.hpp
+++ b/include/netu/impl/basic_timeout.hpp
@@ -24,7 +24,7 @@ struct timeout_entry : boost::intrusive::set_base_hook<>
     friend bool operator<(timeout_entry const& lhs,
                           timeout_entry const& rhs) noexcept
     {
-        return lhs < rhs;
+        return lhs.expiry < rhs.expiry;
     }
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set (netu_tests_srcs
+    netu/basic_timeout.cpp
     netu/completion_handler.cpp
     netu/synchronized_value.cpp
     netu/synchronized_stream.cpp)

--- a/tests/netu/basic_timeout.cpp
+++ b/tests/netu/basic_timeout.cpp
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(timeout_wait_timed_out_immediately)
     BOOST_TEST(invoked == 1);
 }
 
-BOOST_AUTO_TEST_CASE(timeout_wait_cancelled)
+BOOST_AUTO_TEST_CASE(timeout_wait_canceled)
 {
     int invoked2 = 0;
     {
@@ -168,26 +168,7 @@ BOOST_AUTO_TEST_CASE(timeout_move_assignment_into_active_cancels)
     BOOST_TEST(invoked == 1);
 }
 
-BOOST_AUTO_TEST_CASE(timeout_move_assignment_from_active_does_not_cancel)
-{
-    boost::asio::io_context ctx;
-    basic_timeout<boost::asio::steady_timer> t1{ctx};
-
-    int invoked = 0;
-    t1.expires_from_now(duration1);
-    t1.async_wait(verify_success{invoked, ctx.get_executor()});
-    basic_timeout<boost::asio::steady_timer> t2{ctx};
-
-    boost::asio::post(ctx.get_executor(),
-                      [&ctx, &t1, &t2]() { t2 = std::move(t1); });
-
-    ctx.run();
-
-    BOOST_TEST(invoked == 1);
-}
-
-BOOST_AUTO_TEST_CASE(
-  timeout_move_assignment_from_foreign_context_does_not_cancel)
+BOOST_AUTO_TEST_CASE(timeout_move_assignment_from_foreign_context_cancels)
 {
     boost::asio::io_context ctx1;
     boost::asio::io_context ctx2;
@@ -196,8 +177,8 @@ BOOST_AUTO_TEST_CASE(
     basic_timeout<boost::asio::steady_timer> t2{ctx2};
 
     int invoked = 0;
-    t1.expires_from_now(duration1);
-    t1.async_wait(verify_success{invoked, ctx2.get_executor()});
+    t2.expires_from_now(duration1);
+    t2.async_wait(verify_canceled{invoked, ctx2.get_executor()});
 
     boost::asio::post(ctx2.get_executor(),
                       [&ctx2, &t1, &t2]() { t2 = std::move(t1); });

--- a/tests/netu/basic_timeout.cpp
+++ b/tests/netu/basic_timeout.cpp
@@ -13,136 +13,27 @@
 
 #include <boost/asio/post.hpp>
 #include <boost/beast/core/bind_handler.hpp>
+#include <boost/optional.hpp>
 #include <boost/test/unit_test.hpp>
 
 namespace netu
 {
 
-class fake_clock
-{
-public:
-    using inner_clock = std::chrono::steady_clock;
-    using rep = inner_clock::rep;
-    using period = inner_clock::period;
-
-    using duration = inner_clock::duration;
-    using time_point = inner_clock::time_point;
-
-    static time_point now()
-    {
-        return current_time += std::chrono::seconds{1};
-    }
-
-private:
-    static time_point current_time;
-};
-
-fake_clock::time_point fake_clock::current_time =
-  std::chrono::steady_clock::now();
-
-class fake_timer
-{
-public:
-    using clock_type = fake_clock;
-    using duration = clock_type::duration;
-    using executor_type = boost::asio::io_context::executor_type;
-    using time_point = clock_type::time_point;
-    using traits_type = boost::asio::wait_traits<clock_type>;
-
-    explicit fake_timer(boost::asio::io_context& ctx)
-      : ctx_{ctx}
-    {
-    }
-
-    executor_type get_executor() noexcept
-    {
-        return ctx_.get_executor();
-    }
-
-    template<typename CompletionToken>
-    auto async_wait(CompletionToken&& tok)
-      -> detail::wait_completion_result_t<CompletionToken>
-    {
-        detail::wait_completion_t<CompletionToken> init{tok};
-        using ch_t = typename decltype(init)::completion_handler_type;
-        auto op = detail::suspended_handler<ch_t, executor_type>{
-          std::move(init.completion_handler), get_executor()};
-        if (expiry() < clock_type::now())
-        {
-            op(boost::system::error_code{});
-        }
-        else
-        {
-            wait_handler_ = std::move(op);
-        }
-
-        return init.result.get();
-    }
-
-    std::size_t expires_from_now(duration d)
-    {
-        expiration_time_ = clock_type::now() + d;
-        return cancel();
-    }
-
-    std::size_t expires_at(time_point tp)
-    {
-        expiration_time_ = tp;
-        return cancel();
-    }
-
-    std::size_t cancel()
-    {
-        if (wait_handler_)
-        {
-            wait_handler_.invoke(boost::asio::error::operation_aborted);
-            return 1;
-        }
-        else
-        {
-            return 0;
-        }
-    }
-
-    time_point expiry() const
-    {
-        return expiration_time_;
-    }
-
-    std::size_t force_expiration()
-    {
-        if (wait_handler_)
-        {
-            wait_handler_.invoke(boost::system::error_code{});
-            return 1;
-        }
-        else
-        {
-            return 0;
-        }
-    }
-
-private:
-    boost::asio::io_context& ctx_;
-    completion_handler<void(boost::system::error_code)> wait_handler_;
-    time_point expiration_time_;
-};
-
 struct basic_timeout_fixture
 {
     boost::asio::io_context ctx_;
-    basic_timeout<fake_timer> timeout1_{ctx_};
-    basic_timeout<fake_timer> timeout2_{ctx_};
+    basic_timeout<boost::asio::steady_timer> timeout1_{ctx_};
+    basic_timeout<boost::asio::steady_timer> timeout2_{ctx_};
 };
 
-const auto timeout1 = std::chrono::seconds{3};
-const auto timeout2 = std::chrono::seconds{4};
+const auto duration1 = std::chrono::milliseconds{100};
+const auto duration2 = std::chrono::milliseconds{300};
 
 BOOST_AUTO_TEST_CASE(timeout_wait_timed_out)
 {
     basic_timeout_fixture f;
-    f.timeout1_.expires_from_now(timeout1);
-    f.timeout2_.expires_from_now(timeout2);
+    f.timeout1_.expires_from_now(duration1);
+    f.timeout2_.expires_from_now(duration2);
 
     int invoked1 = 0;
     int invoked2 = 0;
@@ -160,16 +51,15 @@ BOOST_AUTO_TEST_CASE(timeout_wait_timed_out)
 
     auto n = f.ctx_.poll();
     BOOST_TEST(n == 0u);
-    // f.timeout1_.get_timer().force_expiration();
-    n = f.ctx_.poll();
+
+    n = f.ctx_.run_for(2 * duration1);
     BOOST_TEST(n > 0u);
     BOOST_TEST(invoked1 == 1);
     BOOST_TEST(invoked2 == 0);
 
     n = f.ctx_.poll();
     BOOST_TEST(n == 0u);
-    // f.timeout2_.get_timer().force_expiration();
-    n = f.ctx_.poll();
+    n = f.ctx_.run_for(2 * duration1);
     BOOST_TEST(n > 0u);
     BOOST_TEST(invoked1 == 1);
     BOOST_TEST(invoked2 == 1);
@@ -178,7 +68,7 @@ BOOST_AUTO_TEST_CASE(timeout_wait_timed_out)
 BOOST_AUTO_TEST_CASE(timeout_wait_timed_out_immediately)
 {
     basic_timeout_fixture f;
-    f.timeout1_.expires_from_now(-timeout1);
+    f.timeout1_.expires_from_now(-duration1);
 
     int invoked = 0;
     f.timeout1_.async_wait([&](boost::system::error_code ec) {
@@ -195,8 +85,8 @@ BOOST_AUTO_TEST_CASE(timeout_wait_cancelled)
     int invoked2 = 0;
     {
         basic_timeout_fixture f;
-        f.timeout1_.expires_from_now(timeout1);
-        f.timeout2_.expires_from_now(timeout2 * 2);
+        f.timeout1_.expires_from_now(duration1);
+        f.timeout2_.expires_from_now(duration2 * 2);
 
         int invoked1 = 0;
         f.timeout1_.async_wait([&](boost::system::error_code ec) {
@@ -214,7 +104,6 @@ BOOST_AUTO_TEST_CASE(timeout_wait_cancelled)
         auto n = f.ctx_.poll();
         BOOST_TEST(n == 0u);
         BOOST_TEST(f.timeout1_.cancel());
-        // f.timeout1_.get_timer().force_expiration();
         n = f.ctx_.poll();
         BOOST_TEST(n > 0u);
         BOOST_TEST(invoked1 == 1);
@@ -223,11 +112,51 @@ BOOST_AUTO_TEST_CASE(timeout_wait_cancelled)
     BOOST_TEST(invoked2 == 0);
 }
 
+BOOST_AUTO_TEST_CASE(timeout_destructor_cancels)
+{
+    boost::asio::io_context ctx;
+    boost::optional<basic_timeout<boost::asio::steady_timer>> t{ctx};
+    t->expires_from_now(duration1);
+
+    int invoked = 0;
+    t->async_wait([&ctx, &invoked](boost::system::error_code ec) {
+        BOOST_TEST(ec == boost::asio::error::operation_aborted);
+        ++invoked;
+        BOOST_ASSERT(ctx.get_executor().running_in_this_thread());
+    });
+
+    boost::asio::post(ctx.get_executor(), [&t]() { t.reset(); });
+    ctx.run();
+
+    BOOST_TEST(invoked == 1);
+}
+
+BOOST_AUTO_TEST_CASE(timeout_move_assignment_cancels)
+{
+    boost::asio::io_context ctx;
+    basic_timeout<boost::asio::steady_timer> t{ctx};
+
+    int invoked = 0;
+    t.expires_from_now(duration1);
+    t.async_wait([&ctx, &invoked](boost::system::error_code ec) {
+        BOOST_TEST(ec == boost::asio::error::operation_aborted);
+        ++invoked;
+        BOOST_ASSERT(ctx.get_executor().running_in_this_thread());
+    });
+
+    boost::asio::post(ctx.get_executor(), [&ctx, &t]() {
+        t = basic_timeout<boost::asio::steady_timer>{ctx};
+    });
+    ctx.run();
+
+    BOOST_TEST(invoked == 1);
+}
+
 BOOST_AUTO_TEST_CASE(timeout_reset)
 {
     basic_timeout_fixture f;
 
-    f.timeout1_.expires_from_now(timeout1);
+    f.timeout1_.expires_from_now(duration1);
     int invoked1 = 0;
     f.timeout1_.async_wait([&](boost::system::error_code ec) {
         BOOST_TEST(ec != boost::asio::error::operation_aborted);
@@ -237,13 +166,13 @@ BOOST_AUTO_TEST_CASE(timeout_reset)
 
     auto n = f.ctx_.poll();
     BOOST_TEST(n == 0);
-    f.timeout1_.expires_from_now(timeout1);
-    n = f.ctx_.poll();
+    f.timeout1_.expires_from_now(duration1);
+    n = f.ctx_.run_for(duration1 / 2);
     BOOST_TEST(n > 0u);
     BOOST_TEST(invoked1 == 0);
 
-    f.timeout1_.expires_from_now(timeout1);
-    n = f.ctx_.poll();
+    f.timeout1_.expires_from_now(duration1);
+    n = f.ctx_.run_for(duration1 / 2);
     BOOST_TEST(n > 0u);
     BOOST_TEST(invoked1 == 0);
 }

--- a/tests/netu/basic_timeout.cpp
+++ b/tests/netu/basic_timeout.cpp
@@ -1,0 +1,194 @@
+//
+// Copyright (c) 2018 Damian Jarek (damian dot jarek93 at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/djarek/netutils
+//
+
+#include <netu/completion_handler.hpp>
+
+#include <netu/basic_timeout.hpp>
+
+#include <boost/asio/post.hpp>
+#include <boost/beast/core/bind_handler.hpp>
+#include <boost/test/unit_test.hpp>
+
+namespace netu
+{
+
+class fake_clock
+{
+public:
+    using inner_clock = std::chrono::steady_clock;
+    using rep = inner_clock::rep;
+    using period = inner_clock::period;
+
+    using duration = inner_clock::duration;
+    using time_point = inner_clock::time_point;
+
+    static time_point now()
+    {
+        return current_time += std::chrono::seconds{1};
+    }
+
+private:
+    static time_point current_time;
+};
+
+fake_clock::time_point fake_clock::current_time =
+  std::chrono::steady_clock::now();
+
+class fake_timer
+{
+public:
+    using clock_type = fake_clock;
+    using duration = clock_type::duration;
+    using executor_type = boost::asio::io_context::executor_type;
+    using time_point = clock_type::time_point;
+    using traits_type = boost::asio::wait_traits<clock_type>;
+
+    explicit fake_timer(boost::asio::io_context& ctx)
+      : ctx_{ctx}
+    {
+    }
+
+    executor_type get_executor() noexcept
+    {
+        return ctx_.get_executor();
+    }
+
+    template<typename CompletionToken>
+    auto async_wait(CompletionToken&& tok)
+      -> detail::wait_completion_result_t<CompletionToken>
+    {
+        detail::wait_completion_t<CompletionToken> init{tok};
+        using ch_t = typename decltype(init)::completion_handler_type;
+        auto op = detail::suspended_handler<ch_t, executor_type>{
+          std::move(init.completion_handler), get_executor()};
+        if (expiry() < clock_type::now())
+        {
+            op(boost::system::error_code{});
+        }
+        else
+        {
+            wait_handler_ = std::move(op);
+        }
+
+        return init.result.get();
+    }
+
+    std::size_t expires_from_now(duration d)
+    {
+        expiration_time_ = clock_type::now() + d;
+        return cancel();
+    }
+
+    std::size_t expires_at(time_point tp)
+    {
+        expiration_time_ = tp;
+        return cancel();
+    }
+
+    std::size_t cancel()
+    {
+        if (wait_handler_)
+        {
+            wait_handler_.invoke(boost::asio::error::operation_aborted);
+            return 1;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+    time_point expiry() const
+    {
+        return expiration_time_;
+    }
+
+    std::size_t force_expiration()
+    {
+        if (wait_handler_)
+        {
+            wait_handler_.invoke(boost::system::error_code{});
+            return 1;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+private:
+    boost::asio::io_context& ctx_;
+    completion_handler<void(boost::system::error_code)> wait_handler_;
+    time_point expiration_time_;
+};
+
+struct basic_timeout_fixture
+{
+    boost::asio::io_context ctx_;
+    basic_timeout<fake_timer> timeout_{ctx_};
+};
+
+const auto timeout = std::chrono::seconds{2};
+
+BOOST_AUTO_TEST_CASE(timeout_wait_timed_out)
+{
+    basic_timeout_fixture f;
+    f.timeout_.expires_from_now(timeout);
+
+    int invoked = 0;
+    f.timeout_.async_wait([&](boost::system::error_code ec) {
+        ++invoked;
+        BOOST_TEST(!ec);
+        BOOST_ASSERT(f.ctx_.get_executor().running_in_this_thread());
+    });
+    auto n = f.ctx_.poll();
+    BOOST_TEST(n == 0u);
+    f.timeout_.get_timer().force_expiration();
+    n = f.ctx_.poll();
+    BOOST_TEST(n == 2u);
+    BOOST_TEST(invoked == 1);
+}
+
+BOOST_AUTO_TEST_CASE(timeout_wait_timed_out_immediately)
+{
+    basic_timeout_fixture f;
+    f.timeout_.expires_from_now(-timeout);
+
+    int invoked = 0;
+    f.timeout_.async_wait([&](boost::system::error_code ec) {
+        ++invoked;
+        BOOST_TEST(!ec);
+        BOOST_ASSERT(f.ctx_.get_executor().running_in_this_thread());
+    });
+    f.ctx_.poll();
+    BOOST_TEST(invoked == 1);
+}
+
+BOOST_AUTO_TEST_CASE(timeout_wait_cancelled)
+{
+    basic_timeout_fixture f;
+    f.timeout_.expires_from_now(timeout);
+
+    int invoked = 0;
+    f.timeout_.async_wait([&](boost::system::error_code ec) {
+        BOOST_TEST(ec == boost::asio::error::operation_aborted);
+        ++invoked;
+        BOOST_ASSERT(f.ctx_.get_executor().running_in_this_thread());
+    });
+
+    auto n = f.ctx_.poll();
+    BOOST_TEST(n == 0u);
+    BOOST_TEST(f.timeout_.cancel());
+    f.timeout_.get_timer().force_expiration();
+    n = f.ctx_.poll();
+    BOOST_TEST(n == 2u);
+    BOOST_TEST(invoked == 1);
+}
+
+} // namespace netu

--- a/tests/netu/basic_timeout.cpp
+++ b/tests/netu/basic_timeout.cpp
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(timeout_wait_timed_out)
 
     auto n = f.ctx_.poll();
     BOOST_TEST(n == 0u);
-    f.timeout1_.get_timer().force_expiration();
+    // f.timeout1_.get_timer().force_expiration();
     n = f.ctx_.poll();
     BOOST_TEST(n > 0u);
     BOOST_TEST(invoked1 == 1);
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(timeout_wait_timed_out)
 
     n = f.ctx_.poll();
     BOOST_TEST(n == 0u);
-    f.timeout2_.get_timer().force_expiration();
+    // f.timeout2_.get_timer().force_expiration();
     n = f.ctx_.poll();
     BOOST_TEST(n > 0u);
     BOOST_TEST(invoked1 == 1);
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(timeout_wait_cancelled)
         auto n = f.ctx_.poll();
         BOOST_TEST(n == 0u);
         BOOST_TEST(f.timeout1_.cancel());
-        f.timeout1_.get_timer().force_expiration();
+        // f.timeout1_.get_timer().force_expiration();
         n = f.ctx_.poll();
         BOOST_TEST(n > 0u);
         BOOST_TEST(invoked1 == 1);

--- a/tests/netu/basic_timeout.cpp
+++ b/tests/netu/basic_timeout.cpp
@@ -223,4 +223,29 @@ BOOST_AUTO_TEST_CASE(timeout_wait_cancelled)
     BOOST_TEST(invoked2 == 0);
 }
 
+BOOST_AUTO_TEST_CASE(timeout_reset)
+{
+    basic_timeout_fixture f;
+
+    f.timeout1_.expires_from_now(timeout1);
+    int invoked1 = 0;
+    f.timeout1_.async_wait([&](boost::system::error_code ec) {
+        BOOST_TEST(ec != boost::asio::error::operation_aborted);
+        ++invoked1;
+        BOOST_ASSERT(f.ctx_.get_executor().running_in_this_thread());
+    });
+
+    auto n = f.ctx_.poll();
+    BOOST_TEST(n == 0);
+    f.timeout1_.expires_from_now(timeout1);
+    n = f.ctx_.poll();
+    BOOST_TEST(n > 0u);
+    BOOST_TEST(invoked1 == 0);
+
+    f.timeout1_.expires_from_now(timeout1);
+    n = f.ctx_.poll();
+    BOOST_TEST(n > 0u);
+    BOOST_TEST(invoked1 == 0);
+}
+
 } // namespace netu

--- a/tests/netu/basic_timeout.cpp
+++ b/tests/netu/basic_timeout.cpp
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(timeout_destructor_cancels)
     BOOST_TEST(invoked == 1);
 }
 
-BOOST_AUTO_TEST_CASE(timeout_move_assignment_cancels)
+BOOST_AUTO_TEST_CASE(timeout_move_assignment_into_active_cancels)
 {
     boost::asio::io_context ctx;
     basic_timeout<boost::asio::steady_timer> t{ctx};


### PR DESCRIPTION
basic_timeout_timer is a wrapper over a timer which represents a timeout for an async operation. The main difference between it and ASIO's timers is that the async operation does not get canceled if the timeout is `reset()`, thus requiring less logic on the client side.
